### PR TITLE
Fix channel->channels typo

### DIFF
--- a/lib/interop.js
+++ b/lib/interop.js
@@ -90,8 +90,8 @@ Interop.prototype.toPlanB = function(desc) {
         // Add sources to the channel and handle a=msid.
         if (typeof mLine.sources === 'object') {
             Object.keys(mLine.sources).forEach(function(ssrc) {
-                if (typeof channel[mLine.type].sources !== 'object')
-                    channel[mLine.type].sources = {};
+                if (typeof channels[mLine.type].sources !== 'object')
+                    channels[mLine.type].sources = {};
 
                 // Assign the sources to the channel.
                 channels[mLine.type].sources[ssrc] = mLine.sources[ssrc];


### PR DESCRIPTION
I can't get the library to run (even with this change), so I'm not sure if this breaks something.
