### PR TITLE
fix(Safari): rtcp-mux, intger mids, double groups

### DIFF
--- a/lib/interop.js
+++ b/lib/interop.js
@@ -21,6 +21,16 @@
 var transform = require('./transform');
 var arrayEquals = require('./array-equals');
 
+/**
+ * Unified Plan mids may be parsed as integers
+ */
+function midToString(line) {
+    if (typeof line.mid === 'number') {
+        line.mid = line.mid.toString();
+    }
+}
+
+
 function Interop() {
 
     /**
@@ -177,10 +187,11 @@ Interop.prototype.toPlanB = function(desc) {
     var directionResult = {};
 
     media.forEach(function(uLine) {
+        midToString(uLine);
         // rtcp-mux is required in the Plan B SDP.
         if ((typeof uLine.rtcpMux !== 'string' ||
             uLine.rtcpMux !== 'rtcp-mux') &&
-            uLine.direction !== 'inactive') {
+            uLine.direction !== 'inactive' && uLine.type !== 'application') {
             throw new Error('Cannot convert to Plan B because m-lines ' +
                 'without the rtcp-mux attribute were found.');
         }
@@ -198,6 +209,7 @@ Interop.prototype.toPlanB = function(desc) {
         var type = uLine.type;
 
         if (type === 'application') {
+            uLine.mid = "data";
             session.media.push(uLine);
             types.push(uLine.mid);
             return;
@@ -236,8 +248,12 @@ Interop.prototype.toPlanB = function(desc) {
                 type2bl[type].ssrcGroups = [];
             }
 
-            type2bl[type].ssrcGroups
-                = type2bl[type].ssrcGroups.concat(uLine.ssrcGroups);
+            // Different ssrc may belong to the same group
+            if (!arrayEquals.apply(type2bl[type].ssrcGroups,
+                                   [uLine.ssrcGroups])) {
+                type2bl[type].ssrcGroups
+                    = type2bl[type].ssrcGroups.concat(uLine.ssrcGroups);
+            }
         }
 
         var direction = uLine.direction;
@@ -388,15 +404,26 @@ Interop.prototype.toUnifiedPlan = function(desc) {
     var uIdx = 0;
 
     session.media.forEach(function(bLine) {
+
         if ((typeof bLine.rtcpMux !== 'string' ||
             bLine.rtcpMux !== 'rtcp-mux') &&
-            bLine.direction !== 'inactive') {
+            bLine.direction !== 'inactive' && bLine.type !== 'application') {
             throw new Error("Cannot convert to Unified Plan because m-lines " +
                 "without the rtcp-mux attribute were found.");
         }
 
         if (bLine.type === 'application') {
-            mid2ul[bLine.mid] = bLine;
+            var uLineData = null;
+            if (cached && cached.media) {
+                uLineData = cached.media.find(function(uLine) {
+                    return uLine.type === 'application';
+                });
+            }
+            if (uLineData) {
+                mid2ul[uLineData.mid] = uLineData;
+            } else {
+                mid2ul[bLine.mid] = bLine;
+            }
             return;
         }
 
@@ -537,6 +564,8 @@ Interop.prototype.toUnifiedPlan = function(desc) {
                         });
                     }
 
+                    midToString(uLine);
+
                     if (typeof uLine.mid === 'undefined') {
 
                         // If this is an SSRC that we see for the first time
@@ -601,6 +630,7 @@ Interop.prototype.toUnifiedPlan = function(desc) {
 
         for (var i = 0; i < cached.media.length; i++) {
             var uLine = cached.media[i];
+            midToString(uLine);
 
             if (typeof mid2ul[uLine.mid] === 'undefined') {
 
@@ -632,7 +662,6 @@ Interop.prototype.toUnifiedPlan = function(desc) {
             }
 
             session.media.push(uLine);
-
             if (typeof uLine.mid === 'string') {
                 // inactive lines don't/may not have an mid.
                 mids.push(uLine.mid);
@@ -652,6 +681,7 @@ Interop.prototype.toUnifiedPlan = function(desc) {
             typeof cached.media !== 'undefined' &&
             Array.isArray(cached.media)) {
             cached.media.forEach(function(uLine) {
+                midToString(uLine);
                 mids.push(uLine.mid);
                 if (typeof mid2ul[uLine.mid] !== 'undefined') {
                     session.media.push(mid2ul[uLine.mid]);
@@ -784,7 +814,7 @@ var directionMasks = {
     'recvonly': 1, // 01
     'sendonly': 2, // 10
     'sendrecv': 3  // 11
-}
+};
 
 /**
  * Parses a number into direction string.
@@ -792,7 +822,7 @@ var directionMasks = {
  * @param {number} direction - The number to be parsed.
  * @returns {string} - The parsed direction string.
  */
-function parseDirection(direction) {
+function parseDirection(direction) { // eslint-disable-line no-unused-vars
     // Filter all other bits except the 2 less significant.
     var directionMask = direction & 3;
 

--- a/test/sdp_interop.js
+++ b/test/sdp_interop.js
@@ -746,6 +746,436 @@ a=rtcp-mux\r\n"
     "Not expected Plan B output")
 });
 
+QUnit.test('SafariUnifiedPlan2PlanB_1track', function (assert) {
+  /*jshint multistr: true */
+    var originUnifiedPlan =
+        "v=0\r\n\
+o=- 5533168490286897077 2 IN IP4 127.0.0.1\r\n\
+s=-\r\n\
+t=0 0\r\n\
+a=group:BUNDLE 0 1 2\r\n\
+a=msid-semantic: WMS 5341c16e-abc0-4e8c-90ba-7b2d8b75daf3\r\n\
+m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 127 125 104\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=rtcp:9 IN IP4 0.0.0.0\r\n\
+a=ice-ufrag:2WGR\r\n\
+a=ice-pwd:Z4funjaI/Ehy5e7xxLlXN4/I\r\n\
+a=ice-options:trickle\r\n\
+a=fingerprint:sha-256 37:84:76:D7:89:5C:5F:44:23:93:C3:8F:92:9F:A3:BB:C7:1E:DF:FB:F7:BF:78:26:E9:05:89:8D:5B:B0:C0:7C\r\n\
+a=setup:actpass\r\n\
+a=mid:0\r\n\
+a=extmap:2 urn:ietf:params:rtp-hdrext:toffset\r\n\
+a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\n\
+a=extmap:4 urn:3gpp:video-orientation\r\n\
+a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\n\
+a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay\r\n\
+a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type\r\n\
+a=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/video-timing\r\n\
+a=extmap:10 http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07\r\n\
+a=extmap:9 urn:ietf:params:rtp-hdrext:sdes:mid\r\n\
+a=sendrecv\r\n\
+a=msid:5341c16e-abc0-4e8c-90ba-7b2d8b75daf3 8b39a943-fad1-47a0-92a8-3bf63fcb8c09\r\n\
+a=rtcp-mux\r\n\
+a=rtcp-rsize\r\n\
+a=rtpmap:96 H264/90000\r\n\
+a=rtcp-fb:96 goog-remb\r\n\
+a=rtcp-fb:96 transport-cc\r\n\
+a=rtcp-fb:96 ccm fir\r\n\
+a=rtcp-fb:96 nack\r\n\
+a=rtcp-fb:96 nack pli\r\n\
+a=fmtp:96 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f\r\n\
+a=rtpmap:97 rtx/90000\r\n\
+a=fmtp:97 apt=96\r\n\
+a=rtpmap:98 H264/90000\r\n\
+a=rtcp-fb:98 goog-remb\r\n\
+a=rtcp-fb:98 transport-cc\r\n\
+a=rtcp-fb:98 ccm fir\r\n\
+a=rtcp-fb:98 nack\r\n\
+a=rtcp-fb:98 nack pli\r\n\
+a=fmtp:98 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f\r\n\
+a=rtpmap:99 rtx/90000\r\n\
+a=fmtp:99 apt=98\r\n\
+a=rtpmap:100 VP8/90000\r\n\
+a=rtcp-fb:100 goog-remb\r\n\
+a=rtcp-fb:100 transport-cc\r\n\
+a=rtcp-fb:100 ccm fir\r\n\
+a=rtcp-fb:100 nack\r\n\
+a=rtcp-fb:100 nack pli\r\n\
+a=rtpmap:101 rtx/90000\r\n\
+a=fmtp:101 apt=100\r\n\
+a=rtpmap:127 red/90000\r\n\
+a=rtpmap:125 rtx/90000\r\n\
+a=fmtp:125 apt=127\r\n\
+a=rtpmap:104 ulpfec/90000\r\n\
+a=ssrc-group:FID 2369716513 624523265\r\n\
+a=ssrc:2369716513 cname:agmig8AM0fZtXKl0\r\n\
+a=ssrc:2369716513 msid:5341c16e-abc0-4e8c-90ba-7b2d8b75daf3 8b39a943-fad1-47a0-92a8-3bf63fcb8c09\r\n\
+a=ssrc:2369716513 mslabel:5341c16e-abc0-4e8c-90ba-7b2d8b75daf3\r\n\
+a=ssrc:2369716513 label:8b39a943-fad1-47a0-92a8-3bf63fcb8c09\r\n\
+a=ssrc:624523265 cname:agmig8AM0fZtXKl0\r\n\
+a=ssrc:624523265 msid:5341c16e-abc0-4e8c-90ba-7b2d8b75daf3 8b39a943-fad1-47a0-92a8-3bf63fcb8c09\r\n\
+a=ssrc:624523265 mslabel:5341c16e-abc0-4e8c-90ba-7b2d8b75daf3\r\n\
+a=ssrc:624523265 label:8b39a943-fad1-47a0-92a8-3bf63fcb8c09\r\n\
+m=audio 9 UDP/TLS/RTP/SAVPF 111 103 9 102 0 8 105 13 110 113 126\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=rtcp:9 IN IP4 0.0.0.0\r\n\
+a=ice-ufrag:2WGR\r\n\
+a=ice-pwd:Z4funjaI/Ehy5e7xxLlXN4/I\r\n\
+a=ice-options:trickle\r\n\
+a=fingerprint:sha-256 37:84:76:D7:89:5C:5F:44:23:93:C3:8F:92:9F:A3:BB:C7:1E:DF:FB:F7:BF:78:26:E9:05:89:8D:5B:B0:C0:7C\r\n\
+a=setup:actpass\r\n\
+a=mid:1\r\n\
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\n\
+a=extmap:9 urn:ietf:params:rtp-hdrext:sdes:mid\r\n\
+a=sendrecv\r\n\
+a=msid:5341c16e-abc0-4e8c-90ba-7b2d8b75daf3 a99c1207-e894-4e21-b133-8fd7de8bd6ea\r\n\
+a=rtcp-mux\r\n\
+a=rtpmap:111 opus/48000/2\r\n\
+a=rtcp-fb:111 transport-cc\r\n\
+a=fmtp:111 minptime=10;useinbandfec=1\r\n\
+a=rtpmap:103 ISAC/16000\r\n\
+a=rtpmap:9 G722/8000\r\n\
+a=rtpmap:102 ILBC/8000\r\n\
+a=rtpmap:0 PCMU/8000\r\n\
+a=rtpmap:8 PCMA/8000\r\n\
+a=rtpmap:105 CN/16000\r\n\
+a=rtpmap:13 CN/8000\r\n\
+a=rtpmap:110 telephone-event/48000\r\n\
+a=rtpmap:113 telephone-event/16000\r\n\
+a=rtpmap:126 telephone-event/8000\r\n\
+a=ssrc:551382772 cname:agmig8AM0fZtXKl0\r\n\
+a=ssrc:551382772 msid:5341c16e-abc0-4e8c-90ba-7b2d8b75daf3 a99c1207-e894-4e21-b133-8fd7de8bd6ea\r\n\
+a=ssrc:551382772 mslabel:5341c16e-abc0-4e8c-90ba-7b2d8b75daf3\r\n\
+a=ssrc:551382772 label:a99c1207-e894-4e21-b133-8fd7de8bd6ea\r\n\
+m=application 9 DTLS/SCTP 5000\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=ice-ufrag:2WGR\r\n\
+a=ice-pwd:Z4funjaI/Ehy5e7xxLlXN4/I\r\n\
+a=ice-options:trickle\r\n\
+a=fingerprint:sha-256 37:84:76:D7:89:5C:5F:44:23:93:C3:8F:92:9F:A3:BB:C7:1E:DF:FB:F7:BF:78:26:E9:05:89:8D:5B:B0:C0:7C\r\n\
+a=setup:actpass\r\n\
+a=mid:2\r\n\
+a=sctpmap:5000 webrtc-datachannel 1024";
+
+  /*jshint multistr: true */
+    var expectedPlanB =
+        "v=0\r\n\
+o=- 5533168490286897077 2 IN IP4 127.0.0.1\r\n\
+s=-\r\n\
+t=0 0\r\n\
+a=msid-semantic: WMS *\r\n\
+a=group:BUNDLE video audio data\r\n\
+m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 127 125 104\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=rtpmap:96 H264/90000\r\n\
+a=rtpmap:97 rtx/90000\r\n\
+a=rtpmap:98 H264/90000\r\n\
+a=rtpmap:99 rtx/90000\r\n\
+a=rtpmap:100 VP8/90000\r\n\
+a=rtpmap:101 rtx/90000\r\n\
+a=rtpmap:127 red/90000\r\n\
+a=rtpmap:125 rtx/90000\r\n\
+a=rtpmap:104 ulpfec/90000\r\n\
+a=fmtp:96 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f\r\n\
+a=fmtp:97 apt=96\r\n\
+a=fmtp:98 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f\r\n\
+a=fmtp:99 apt=98\r\n\
+a=fmtp:101 apt=100\r\n\
+a=fmtp:125 apt=127\r\n\
+a=rtcp:9 IN IP4 0.0.0.0\r\n\
+a=rtcp-fb:96 goog-remb\r\n\
+a=rtcp-fb:96 transport-cc\r\n\
+a=rtcp-fb:96 ccm fir\r\n\
+a=rtcp-fb:96 nack\r\n\
+a=rtcp-fb:96 nack pli\r\n\
+a=rtcp-fb:98 goog-remb\r\n\
+a=rtcp-fb:98 transport-cc\r\n\
+a=rtcp-fb:98 ccm fir\r\n\
+a=rtcp-fb:98 nack\r\n\
+a=rtcp-fb:98 nack pli\r\n\
+a=rtcp-fb:100 goog-remb\r\n\
+a=rtcp-fb:100 transport-cc\r\n\
+a=rtcp-fb:100 ccm fir\r\n\
+a=rtcp-fb:100 nack\r\n\
+a=rtcp-fb:100 nack pli\r\n\
+a=extmap:2 urn:ietf:params:rtp-hdrext:toffset\r\n\
+a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\n\
+a=extmap:4 urn:3gpp:video-orientation\r\n\
+a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\n\
+a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay\r\n\
+a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type\r\n\
+a=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/video-timing\r\n\
+a=extmap:10 http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07\r\n\
+a=extmap:9 urn:ietf:params:rtp-hdrext:sdes:mid\r\n\
+a=setup:actpass\r\n\
+a=mid:video\r\n\
+a=sendrecv\r\n\
+a=ice-ufrag:2WGR\r\n\
+a=ice-pwd:Z4funjaI/Ehy5e7xxLlXN4/I\r\n\
+a=fingerprint:sha-256 37:84:76:D7:89:5C:5F:44:23:93:C3:8F:92:9F:A3:BB:C7:1E:DF:FB:F7:BF:78:26:E9:05:89:8D:5B:B0:C0:7C\r\n\
+a=ice-options:trickle\r\n\
+a=ssrc:624523265 cname:agmig8AM0fZtXKl0\r\n\
+a=ssrc:624523265 msid:5341c16e-abc0-4e8c-90ba-7b2d8b75daf3 8b39a943-fad1-47a0-92a8-3bf63fcb8c09\r\n\
+a=ssrc:624523265 mslabel:5341c16e-abc0-4e8c-90ba-7b2d8b75daf3\r\n\
+a=ssrc:624523265 label:8b39a943-fad1-47a0-92a8-3bf63fcb8c09\r\n\
+a=ssrc:2369716513 cname:agmig8AM0fZtXKl0\r\n\
+a=ssrc:2369716513 msid:5341c16e-abc0-4e8c-90ba-7b2d8b75daf3 8b39a943-fad1-47a0-92a8-3bf63fcb8c09\r\n\
+a=ssrc:2369716513 mslabel:5341c16e-abc0-4e8c-90ba-7b2d8b75daf3\r\n\
+a=ssrc:2369716513 label:8b39a943-fad1-47a0-92a8-3bf63fcb8c09\r\n\
+a=ssrc-group:FID 2369716513 624523265\r\n\
+a=rtcp-mux\r\n\
+a=rtcp-rsize\r\n\
+m=audio 9 UDP/TLS/RTP/SAVPF 111 103 9 102 0 8 105 13 110 113 126\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=rtpmap:111 opus/48000/2\r\n\
+a=rtpmap:103 ISAC/16000\r\n\
+a=rtpmap:9 G722/8000\r\n\
+a=rtpmap:102 ILBC/8000\r\n\
+a=rtpmap:0 PCMU/8000\r\n\
+a=rtpmap:8 PCMA/8000\r\n\
+a=rtpmap:105 CN/16000\r\n\
+a=rtpmap:13 CN/8000\r\n\
+a=rtpmap:110 telephone-event/48000\r\n\
+a=rtpmap:113 telephone-event/16000\r\n\
+a=rtpmap:126 telephone-event/8000\r\n\
+a=fmtp:111 minptime=10;useinbandfec=1\r\n\
+a=rtcp:9 IN IP4 0.0.0.0\r\n\
+a=rtcp-fb:111 transport-cc\r\n\
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\n\
+a=extmap:9 urn:ietf:params:rtp-hdrext:sdes:mid\r\n\
+a=setup:actpass\r\n\
+a=mid:audio\r\n\
+a=sendrecv\r\n\
+a=ice-ufrag:2WGR\r\n\
+a=ice-pwd:Z4funjaI/Ehy5e7xxLlXN4/I\r\n\
+a=fingerprint:sha-256 37:84:76:D7:89:5C:5F:44:23:93:C3:8F:92:9F:A3:BB:C7:1E:DF:FB:F7:BF:78:26:E9:05:89:8D:5B:B0:C0:7C\r\n\
+a=ice-options:trickle\r\n\
+a=ssrc:551382772 cname:agmig8AM0fZtXKl0\r\n\
+a=ssrc:551382772 msid:5341c16e-abc0-4e8c-90ba-7b2d8b75daf3 a99c1207-e894-4e21-b133-8fd7de8bd6ea\r\n\
+a=ssrc:551382772 mslabel:5341c16e-abc0-4e8c-90ba-7b2d8b75daf3\r\n\
+a=ssrc:551382772 label:a99c1207-e894-4e21-b133-8fd7de8bd6ea\r\n\
+a=rtcp-mux\r\n\
+m=application 9 DTLS/SCTP 5000\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=setup:actpass\r\n\
+a=mid:data\r\n\
+a=ice-ufrag:2WGR\r\n\
+a=ice-pwd:Z4funjaI/Ehy5e7xxLlXN4/I\r\n\
+a=fingerprint:sha-256 37:84:76:D7:89:5C:5F:44:23:93:C3:8F:92:9F:A3:BB:C7:1E:DF:FB:F7:BF:78:26:E9:05:89:8D:5B:B0:C0:7C\r\n\
+a=ice-options:trickle\r\n\
+a=sctpmap:5000 webrtc-datachannel 1024\r\n";
+
+  var interop = new Interop();
+
+  var offer = new RTCSessionDescription({
+    type: 'offer',
+    sdp: originUnifiedPlan
+  });
+
+  var planBDesc = interop.toPlanB(offer);
+  assert.equal(planBDesc.sdp, expectedPlanB,
+    "Not expected Plan B output");
+});
+
+QUnit.test('ChromeUnifiedPlan2PlanB_1track', function (assert) {
+  /*jshint multistr: true */
+    var originUnifiedPlan =
+    "v=0\r\n\
+o=- 1184191167523818338 2 IN IP4 127.0.0.1\r\n\
+s=-\r\n\
+t=0 0\r\n\
+a=group:BUNDLE 0 1 2\r\n\
+a=msid-semantic: WMS 3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm\r\n\
+m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=rtcp:9 IN IP4 0.0.0.0\r\n\
+a=ice-ufrag:csgF\r\n\
+a=ice-pwd:7R1rGkjhdgVvhWreoWc/wyK5\r\n\
+a=ice-options:trickle\r\n\
+a=fingerprint:sha-256 8B:54:38:8B:AE:32:4D:FA:D7:1B:45:A2:A7:1D:CD:74:3F:6B:47:16:A3:81:F3:FD:0E:EE:DA:5C:08:9B:AB:AF\r\n\
+a=setup:actpass\r\n\
+a=mid:0\r\n\
+a=extmap:2 urn:ietf:params:rtp-hdrext:toffset\r\n\
+a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\n\
+a=extmap:4 urn:3gpp:video-orientation\r\n\
+a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\n\
+a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay\r\n\
+a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type\r\n\
+a=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/video-timing\r\n\
+a=extmap:10 http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07\r\n\
+a=extmap:9 urn:ietf:params:rtp-hdrext:sdes:mid\r\n\
+a=sendrecv\r\n\
+a=msid:3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm c7bbcec4-d97a-4a5a-9337-a00ad0ccc3b1\r\n\
+a=rtcp-mux\r\n\
+a=rtcp-rsize\r\n\
+a=rtpmap:96 VP8/90000\r\n\
+a=rtcp-fb:96 goog-remb\r\n\
+a=rtcp-fb:96 transport-cc\r\n\
+a=rtcp-fb:96 ccm fir\r\n\
+a=rtcp-fb:96 nack\r\n\
+a=rtcp-fb:96 nack pli\r\n\
+a=rtpmap:97 rtx/90000\r\n\
+a=fmtp:97 apt=96\r\n\
+a=rtpmap:98 red/90000\r\n\
+a=rtpmap:99 rtx/90000\r\n\
+a=fmtp:99 apt=98\r\n\
+a=rtpmap:100 ulpfec/90000\r\n\
+a=ssrc-group:FID 586659339 3877438672\r\n\
+a=ssrc:586659339 cname:ZbOF5IZHvUC1PdUR\r\n\
+a=ssrc:586659339 msid:3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm c7bbcec4-d97a-4a5a-9337-a00ad0ccc3b1\r\n\
+a=ssrc:586659339 mslabel:3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm\r\n\
+a=ssrc:586659339 label:c7bbcec4-d97a-4a5a-9337-a00ad0ccc3b1\r\n\
+a=ssrc:3877438672 cname:ZbOF5IZHvUC1PdUR\r\n\
+a=ssrc:3877438672 msid:3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm c7bbcec4-d97a-4a5a-9337-a00ad0ccc3b1\r\n\
+a=ssrc:3877438672 mslabel:3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm\r\n\
+a=ssrc:3877438672 label:c7bbcec4-d97a-4a5a-9337-a00ad0ccc3b1\r\n\
+m=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=rtcp:9 IN IP4 0.0.0.0\r\n\
+a=ice-ufrag:csgF\r\n\
+a=ice-pwd:7R1rGkjhdgVvhWreoWc/wyK5\r\n\
+a=ice-options:trickle\r\n\
+a=fingerprint:sha-256 8B:54:38:8B:AE:32:4D:FA:D7:1B:45:A2:A7:1D:CD:74:3F:6B:47:16:A3:81:F3:FD:0E:EE:DA:5C:08:9B:AB:AF\r\n\
+a=setup:actpass\r\n\
+a=mid:1\r\n\
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\n\
+a=extmap:9 urn:ietf:params:rtp-hdrext:sdes:mid\r\n\
+a=sendrecv\r\n\
+a=msid:3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm aebd99ff-12cf-426e-a37d-5586d3017541\r\n\
+a=rtcp-mux\r\n\
+a=rtpmap:111 opus/48000/2\r\n\
+a=rtcp-fb:111 transport-cc\r\n\
+a=fmtp:111 minptime=10;useinbandfec=1\r\n\
+a=rtpmap:103 ISAC/16000\r\n\
+a=rtpmap:104 ISAC/32000\r\n\
+a=rtpmap:9 G722/8000\r\n\
+a=rtpmap:0 PCMU/8000\r\n\
+a=rtpmap:8 PCMA/8000\r\n\
+a=rtpmap:106 CN/32000\r\n\
+a=rtpmap:105 CN/16000\r\n\
+a=rtpmap:13 CN/8000\r\n\
+a=rtpmap:110 telephone-event/48000\r\n\
+a=rtpmap:112 telephone-event/32000\r\n\
+a=rtpmap:113 telephone-event/16000\r\n\
+a=rtpmap:126 telephone-event/8000\r\n\
+a=ssrc:601007326 cname:ZbOF5IZHvUC1PdUR\r\n\
+a=ssrc:601007326 msid:3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm aebd99ff-12cf-426e-a37d-5586d3017541\r\n\
+a=ssrc:601007326 mslabel:3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm\r\n\
+a=ssrc:601007326 label:aebd99ff-12cf-426e-a37d-5586d3017541\r\n\
+m=application 9 DTLS/SCTP 5000\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=ice-ufrag:csgF\r\n\
+a=ice-pwd:7R1rGkjhdgVvhWreoWc/wyK5\r\n\
+a=ice-options:trickle\r\n\
+a=fingerprint:sha-256 8B:54:38:8B:AE:32:4D:FA:D7:1B:45:A2:A7:1D:CD:74:3F:6B:47:16:A3:81:F3:FD:0E:EE:DA:5C:08:9B:AB:AF\r\n\
+a=setup:actpass\r\n\
+a=mid:2\r\n\
+a=sctpmap:5000 webrtc-datachannel 1024";
+
+  /*jshint multistr: true */
+    var expectedPlanB =
+    "v=0\r\n\
+o=- 1184191167523818338 2 IN IP4 127.0.0.1\r\n\
+s=-\r\n\
+t=0 0\r\n\
+a=msid-semantic: WMS *\r\n\
+a=group:BUNDLE video audio data\r\n\
+m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=rtpmap:96 VP8/90000\r\n\
+a=rtpmap:97 rtx/90000\r\n\
+a=rtpmap:98 red/90000\r\n\
+a=rtpmap:99 rtx/90000\r\n\
+a=rtpmap:100 ulpfec/90000\r\n\
+a=fmtp:97 apt=96\r\n\
+a=fmtp:99 apt=98\r\n\
+a=rtcp:9 IN IP4 0.0.0.0\r\n\
+a=rtcp-fb:96 goog-remb\r\n\
+a=rtcp-fb:96 transport-cc\r\n\
+a=rtcp-fb:96 ccm fir\r\n\
+a=rtcp-fb:96 nack\r\n\
+a=rtcp-fb:96 nack pli\r\n\
+a=extmap:2 urn:ietf:params:rtp-hdrext:toffset\r\n\
+a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\n\
+a=extmap:4 urn:3gpp:video-orientation\r\n\
+a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\n\
+a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay\r\n\
+a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type\r\n\
+a=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/video-timing\r\n\
+a=extmap:10 http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07\r\n\
+a=extmap:9 urn:ietf:params:rtp-hdrext:sdes:mid\r\n\
+a=setup:actpass\r\n\
+a=mid:video\r\n\
+a=sendrecv\r\n\
+a=ice-ufrag:csgF\r\n\
+a=ice-pwd:7R1rGkjhdgVvhWreoWc/wyK5\r\n\
+a=fingerprint:sha-256 8B:54:38:8B:AE:32:4D:FA:D7:1B:45:A2:A7:1D:CD:74:3F:6B:47:16:A3:81:F3:FD:0E:EE:DA:5C:08:9B:AB:AF\r\n\
+a=ice-options:trickle\r\n\
+a=ssrc:586659339 cname:ZbOF5IZHvUC1PdUR\r\n\
+a=ssrc:586659339 msid:3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm c7bbcec4-d97a-4a5a-9337-a00ad0ccc3b1\r\n\
+a=ssrc:586659339 mslabel:3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm\r\n\
+a=ssrc:586659339 label:c7bbcec4-d97a-4a5a-9337-a00ad0ccc3b1\r\n\
+a=ssrc:3877438672 cname:ZbOF5IZHvUC1PdUR\r\n\
+a=ssrc:3877438672 msid:3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm c7bbcec4-d97a-4a5a-9337-a00ad0ccc3b1\r\n\
+a=ssrc:3877438672 mslabel:3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm\r\n\
+a=ssrc:3877438672 label:c7bbcec4-d97a-4a5a-9337-a00ad0ccc3b1\r\n\
+a=ssrc-group:FID 586659339 3877438672\r\n\
+a=rtcp-mux\r\n\
+a=rtcp-rsize\r\n\
+m=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=rtpmap:111 opus/48000/2\r\n\
+a=rtpmap:103 ISAC/16000\r\n\
+a=rtpmap:104 ISAC/32000\r\n\
+a=rtpmap:9 G722/8000\r\n\
+a=rtpmap:0 PCMU/8000\r\n\
+a=rtpmap:8 PCMA/8000\r\n\
+a=rtpmap:106 CN/32000\r\n\
+a=rtpmap:105 CN/16000\r\n\
+a=rtpmap:13 CN/8000\r\n\
+a=rtpmap:110 telephone-event/48000\r\n\
+a=rtpmap:112 telephone-event/32000\r\n\
+a=rtpmap:113 telephone-event/16000\r\n\
+a=rtpmap:126 telephone-event/8000\r\n\
+a=fmtp:111 minptime=10;useinbandfec=1\r\n\
+a=rtcp:9 IN IP4 0.0.0.0\r\n\
+a=rtcp-fb:111 transport-cc\r\n\
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\n\
+a=extmap:9 urn:ietf:params:rtp-hdrext:sdes:mid\r\n\
+a=setup:actpass\r\n\
+a=mid:audio\r\n\
+a=sendrecv\r\n\
+a=ice-ufrag:csgF\r\n\
+a=ice-pwd:7R1rGkjhdgVvhWreoWc/wyK5\r\n\
+a=fingerprint:sha-256 8B:54:38:8B:AE:32:4D:FA:D7:1B:45:A2:A7:1D:CD:74:3F:6B:47:16:A3:81:F3:FD:0E:EE:DA:5C:08:9B:AB:AF\r\n\
+a=ice-options:trickle\r\n\
+a=ssrc:601007326 cname:ZbOF5IZHvUC1PdUR\r\n\
+a=ssrc:601007326 msid:3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm aebd99ff-12cf-426e-a37d-5586d3017541\r\n\
+a=ssrc:601007326 mslabel:3aj65EJGUaqJSTX4DTDRl8ssk3irHnJZ3jWm\r\n\
+a=ssrc:601007326 label:aebd99ff-12cf-426e-a37d-5586d3017541\r\n\
+a=rtcp-mux\r\n\
+m=application 9 DTLS/SCTP 5000\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=setup:actpass\r\n\
+a=mid:data\r\n\
+a=ice-ufrag:csgF\r\n\
+a=ice-pwd:7R1rGkjhdgVvhWreoWc/wyK5\r\n\
+a=fingerprint:sha-256 8B:54:38:8B:AE:32:4D:FA:D7:1B:45:A2:A7:1D:CD:74:3F:6B:47:16:A3:81:F3:FD:0E:EE:DA:5C:08:9B:AB:AF\r\n\
+a=ice-options:trickle\r\n\
+a=sctpmap:5000 webrtc-datachannel 1024\r\n";
+
+  var interop = new Interop();
+
+  var offer = new RTCSessionDescription({
+    type: 'offer',
+    sdp: originUnifiedPlan
+  });
+
+  var planBDesc = interop.toPlanB(offer);
+  assert.equal(planBDesc.sdp, expectedPlanB,
+    "Not expected Plan B output");
+});
+
 QUnit.test('3-way-jitsi', function (assert) {
 
   var interop = new Interop();


### PR DESCRIPTION
1. Safari, Chromium and sometimes Firefox don't set rtp-mux on data channel.
2. Safari and Chromium by default generate integer mids i.e. 1, 2, 3. It's parsed as integer and confuses `indexOf()`, which results in several identical m-lines.
3. Different ssrcs may belong to a same group, generated Plan-B may have duplicated ssrc-group lines in that case.

These fixes eliminate Safari errors in Unified-Plan mode. Chromium with Unified Plan and these fixes and without Simulcast starts sending video and audio but there're still problems with receiving media, that could be not related to sdp-interop