### PR TITLE
Support replacing tracks

### DIFF
--- a/lib/interop.js
+++ b/lib/interop.js
@@ -402,10 +402,18 @@ export class Interop {
                 } else {
                     const newMline = clonedeep(mLine);
 
-                    newMline.mid = currentDesc.media.length.toString();
                     newMline.direction = 'sendonly';
                     addSourcesToMline(newMline, ssrc, ssrc2group, mLine.sources);
-                    currentDesc.media.push(newMline);
+
+                    const replacedMid = currentDesc.media.findIndex(cmLine => cmLine.msid === newMline.msid);
+
+                    if (replacedMid > -1) {
+                        newMline.mid = currentDesc.media[replacedMid].mid;
+                        currentDesc.media[replacedMid] = newMline;
+                    } else {
+                        newMline.mid = currentDesc.media.length.toString();
+                        currentDesc.media.push(newMline);
+                    }
                 }
             });
         });


### PR DESCRIPTION
On reconnect client sends new tracks with new ssrc.
`toUnifiedPlan(newSdp, currentSdp)` adds new tracks and `ontrack` callback fires.
To fix this problem i added this check.