### PR TITLE
add extension to export

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,4 +13,4 @@
  * limitations under the License.
  */
 
-export * from './interop';
+export * from './interop.js';


### PR DESCRIPTION
I got the below build error trying to build `lib-jitsi-meet` with webpack 5 and therefore added the `js` extension.

```
WARNING in ./modules/RTC/TraceablePeerConnection.js 236:21-28
export 'Interop' (imported as 'Interop') was not found in '@jitsi/sdp-interop' (possible exports: )
 @ ./modules/RTC/RTC.js 21:0-64 501:30-53
 @ ./JitsiMeetJS.js 14:0-36 211:11-19 220:11-38 232:11-32 335:11-45 340:11-41 355:45-82
 @ ./index.js 3:0-49

ERROR in ./node_modules/@jitsi/sdp-interop/lib/index.js 16:0-26
Module not found: Error: Can't resolve './interop' in '/home/rhalff/development/lib-jitsi-meet/node_modules/@jitsi/sdp-interop/lib'
Did you mean 'interop.js'?
BREAKING CHANGE: The request './interop' failed to resolve only because it was resolved as fully specified
(probably because the origin is a '*.mjs' file or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
 @ ./modules/RTC/TraceablePeerConnection.js 2:0-45 236:21-28
 @ ./modules/RTC/RTC.js 21:0-64 501:30-53
 @ ./JitsiMeetJS.js 14:0-36 211:11-19 220:11-38 232:11-32 335:11-45 340:11-41 355:45-82
 @ ./index.js 3:0-49

```

