### PR TITLE
fix: Add a media desc even when there are no remote sources.

### DIFF
--- a/lib/interop.js
+++ b/lib/interop.js
@@ -357,7 +357,17 @@ export class Interop {
             // Create an inverted sourceGroup map here to put all the grouped SSRCs in the same m-line.
             const ssrc2group = createSourceGroupMap(mLine.ssrcGroups);
 
+            // If there are no sources advertised for a media type, add the description if this is the first
+            // remote offer, i.e., no current description was passed. Chrome in Unified plan does not produce
+            // recvonly ssrcs unlike Firefox and Safari.
             if (!mLine.sources) {
+                if (!currentDesc) {
+                    const newMline = clonedeep(mLine);
+
+                    newMline.mid = Object.keys(media).length.toString();
+                    media[mLine.mid] = newMline;
+                }
+
                 return;
             }
             mLine.sources.forEach((ssrc, idx) => {

--- a/test/sdp_interop.js
+++ b/test/sdp_interop.js
@@ -1274,6 +1274,81 @@ a=rtcp-mux\r\n";
     "Not expected Plan B output");
 });
 
+QUnit.test('planBToUnifiedNoSources', function (assert) {
+  /*jshint multistr: true */
+  var originPlanB =
+    "v=0\r\n\
+o=- 6352417452822806569 2 IN IP4 127.0.0.1\r\n\
+s=-\r\n\
+t=0 0\r\n\
+a=group:BUNDLE audio video\r\n\
+a=msid-semantic: WMS MS-0\r\n\
+m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=rtcp:9 IN IP4 0.0.0.0\r\n\
+a=ice-ufrag:xHOGnBsKDPCmHB5t\r\n\
+a=ice-pwd:qpnbhhoyeTrypBkX5F1u338T\r\n\
+a=fingerprint:sha-256 58:E0:FE:56:6A:8C:5A:AD:71:5B:A0:52:47:27:60:66:27:53:EC:B6:F3:03:A8:4B:9B:30:28:62:29:49:C6:73\r\n\
+a=setup:actpass\r\n\
+a=mid:audio\r\n\
+a=recvonly\r\n\
+a=rtcp-mux\r\n\
+a=rtpmap:111 opus/48000/2\r\n\
+m=video 9 UDP/TLS/RTP/SAVPF 100\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=rtcp:9 IN IP4 0.0.0.0\r\n\
+a=ice-ufrag:xHOGnBsKDPCmHB5t\r\n\
+a=ice-pwd:qpnbhhoyeTrypBkX5F1u338T\r\n\
+a=fingerprint:sha-256 58:E0:FE:56:6A:8C:5A:AD:71:5B:A0:52:47:27:60:66:27:53:EC:B6:F3:03:A8:4B:9B:30:28:62:29:49:C6:73\r\n\
+a=setup:actpass\r\n\
+a=mid:video\r\n\
+a=recvonly\r\n\
+a=rtcp-mux\r\n\
+a=rtpmap:100 VP8/90000\r\n"
+
+  /*jshint multistr: true */
+  var expectedUnifiedPlan =
+    "v=0\r\n\
+o=- 6352417452822806569 3 IN IP4 127.0.0.1\r\n\
+s=-\r\n\
+t=0 0\r\n\
+a=msid-semantic: WMS *\r\n\
+a=group:BUNDLE 0 1\r\n\
+m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=rtpmap:111 opus/48000/2\r\n\
+a=rtcp:9 IN IP4 0.0.0.0\r\n\
+a=setup:actpass\r\n\
+a=mid:0\r\n\
+a=recvonly\r\n\
+a=ice-ufrag:xHOGnBsKDPCmHB5t\r\n\
+a=ice-pwd:qpnbhhoyeTrypBkX5F1u338T\r\n\
+a=fingerprint:sha-256 58:E0:FE:56:6A:8C:5A:AD:71:5B:A0:52:47:27:60:66:27:53:EC:B6:F3:03:A8:4B:9B:30:28:62:29:49:C6:73\r\n\
+a=rtcp-mux\r\n\
+m=video 9 UDP/TLS/RTP/SAVPF 100\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=rtpmap:100 VP8/90000\r\n\
+a=rtcp:9 IN IP4 0.0.0.0\r\n\
+a=setup:actpass\r\n\
+a=mid:1\r\n\
+a=recvonly\r\n\
+a=ice-ufrag:xHOGnBsKDPCmHB5t\r\n\
+a=ice-pwd:qpnbhhoyeTrypBkX5F1u338T\r\n\
+a=fingerprint:sha-256 58:E0:FE:56:6A:8C:5A:AD:71:5B:A0:52:47:27:60:66:27:53:EC:B6:F3:03:A8:4B:9B:30:28:62:29:49:C6:73\r\n\
+a=rtcp-mux\r\n"
+
+  var interop = new Interop();
+
+  var offer = new RTCSessionDescription({
+    type: 'offer',
+    sdp: originPlanB
+  });
+
+  var unifiedPlanDesc = interop.toUnifiedPlan(offer);
+  assert.equal(unifiedPlanDesc.sdp, expectedUnifiedPlan,
+    "Not expected Unified Plan output")
+});
+
 QUnit.test('3-way-jitsi', function (assert) {
 
   var interop = new Interop();


### PR DESCRIPTION
Chrome in unified plan does not add the recvonly ssrcs in the offer when no local tracks are present. This could result in no media desc being added to the coverted unified plan desc.