### PR TITLE
fix: Do not try to re-use inactive mid for new remote ssrcs.

### DIFF
--- a/lib/interop.js
+++ b/lib/interop.js
@@ -399,24 +399,12 @@ export class Interop {
                 if (checkIfMlineForSsrcExists(ssrc, ssrc2group, currentDesc.media)) {
                     return;
                 }
+                const newMline = clonedeep(mLine);
 
-                // check if there is a m-line that is inactive and is of the same media type
-                const inactiveMid = currentDesc.media
-                    .findIndex(cmLine => cmLine.direction
-                        && cmLine.direction === 'inactive'
-                        && cmLine.type === type);
-
-                if (inactiveMid > -1) {
-                    currentDesc.media[inactiveMid].direction = 'sendonly';
-                    addSourcesToMline(currentDesc.media[inactiveMid], ssrc, ssrc2group, mLine.sources);
-                } else {
-                    const newMline = clonedeep(mLine);
-
-                    newMline.mid = currentDesc.media.length.toString();
-                    newMline.direction = 'sendonly';
-                    addSourcesToMline(newMline, ssrc, ssrc2group, mLine.sources);
-                    currentDesc.media.push(newMline);
-                }
+                newMline.mid = currentDesc.media.length.toString();
+                newMline.direction = 'sendonly';
+                addSourcesToMline(newMline, ssrc, ssrc2group, mLine.sources);
+                currentDesc.media.push(newMline);
             });
         });
         session.media = currentDesc ? currentDesc.media : Object.values(media);


### PR DESCRIPTION
The direction was marked as 'inactive' only on Firefox as Safari had audio issues when an inactive mid is re-used. Chrome (in unified-plan) needs the direction of the mid in remote desc to be set to 'inactive' for a 'removetrack' to be fired on the associated media stream whenever a remote source is removed.