### PR TITLE
fix: always preserve the fingerprint in toUnifiedPlan()

### DIFF
--- a/lib/interop.js
+++ b/lib/interop.js
@@ -437,8 +437,8 @@ export class Interop {
             if (iceRestart) {
                 mLine.iceUfrag = newIceUfrag;
                 mLine.icePwd = newIcePwd;
-                mLine.fingerprint = newFingerprint;
             }
+            mLine.fingerprint = newFingerprint;
         });
 
         // We regenerate the BUNDLE group (since we regenerated the mids)


### PR DESCRIPTION
This PR preserves the fingerprint value independent of the detection of an ICE restart. This is needed to enable detection of the desired DTLS restart in the second O/A round during ICE restart.